### PR TITLE
♻️ use SSL for localhost

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ You can open a new issue with this [issue form](https://github.com/fredkiss3/zan
     caddy run
     ```
 
-    The API will be available at [http://zane.local](http://zane.local).
+    The API will be available at [https://zane.local](https://zane.local).
 
 7. **Open the source code and start rocking ! 😎**
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-http://zane.local {
+zane.local {
 	handle /api/* {
 		reverse_proxy http://127.0.0.1:8000
 	}

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -34,6 +34,8 @@ DEBUG = not env == PRODUCTION_ENV
 CSRF_COOKIE_SECURE = True
 SESSION_COOKIE_SECURE = True
 
+## We will only support one root domain on production
+## And it will be in the format domain.com (without `http://` or `https://`)
 root_domain = os.environ.get("ROOT_DOMAIN")
 ALLOWED_HOSTS = (
     ["zane.local", "localhost", "127.0.0.1"] if root_domain is None else [root_domain]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -41,6 +41,7 @@ ALLOWED_HOSTS = (
     ["zane.local", "localhost", "127.0.0.1"] if root_domain is None else [root_domain]
 )
 
+## This is necessary for making sure that CSRF protections work on production
 CSRF_TRUSTED_ORIGINS = (
     ["http://zane.local", "https://zane.local"]
     if root_domain is None

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -31,12 +31,18 @@ PRODUCTION_ENV = "PRODUCTION"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = not env == PRODUCTION_ENV
-CSRF_COOKIE_SECURE = env == PRODUCTION_ENV
-SESSION_COOKIE_SECURE = env == PRODUCTION_ENV
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
 
-hosts = os.environ.get("ALLOWED_HOSTS")
+root_domain = os.environ.get("ROOT_DOMAIN")
 ALLOWED_HOSTS = (
-    ["zane.local", "localhost", "127.0.0.1"] if hosts is None else hosts.split(",")
+    ["zane.local", "localhost", "127.0.0.1"] if root_domain is None else [root_domain]
+)
+
+CSRF_TRUSTED_ORIGINS = (
+    ["http://zane.local", "https://zane.local"]
+    if root_domain is None
+    else [f"https://{root_domain}"]
 )
 
 CACHES = {


### PR DESCRIPTION
## Description

This is a small PR for enforcing the usage of SSL even in localhost, this helped me foresee an issue regarding  CSRF and its usage with SSL, if a domain with https isn't included in `settings.py`, CSRF protection won't work : 

```json
{ 
  "detail": "CSRF Failed: Origin checking failed - https://zane.local does not match any trusted origins."
}
```

Since we want to enforce CSRF for the users who will install this app, we want to make sure that it will work as expected for them.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
