### PR TITLE
:recycle: Use functions instead of classes for services

### DIFF
--- a/backend/zane_api/services.py
+++ b/backend/zane_api/services.py
@@ -5,6 +5,29 @@ import docker.errors
 
 from .models import Project
 
+docker_client: docker.DockerClient | None = None
+DOCKER_HUB_REGISTRY_URL = 'registry-1.docker.io/v2'
+
+
+def get_docker_client():
+    """
+    Get docker client
+    """
+    global docker_client
+    if docker_client is None:
+        print("Recreate docker client")
+        docker_client = docker.from_env()
+    return docker_client
+
+
+def get_resource_name(project: Project, resource_type: str) -> str:
+    match resource_type:
+        case 'network':
+            ts_to_full_number = str(project.created_at.timestamp()).replace(".", "")
+            return f"{project.slug}-{ts_to_full_number}"
+        case _:
+            raise ValueError(f"resource type '{resource_type}' is not supported")
+
 
 class DockerImageResultFromRegistry(TypedDict):
     name: str
@@ -18,95 +41,87 @@ class DockerImageResult(TypedDict):
     description: str
 
 
-class DockerService:
-    client: docker.DockerClient | None = None
-    DOCKER_HUB_REGISTRY_URL = 'registry-1.docker.io/v2'
+def search_docker_registry(term: str) -> List[DockerImageResult]:
+    """
+    List all images in registry starting with a certain term.
+    """
+    client = get_docker_client()
+    result: List[DockerImageResultFromRegistry] = client.images.search(term=term, limit=30)
+    images_to_return: List[DockerImageResult] = []
 
-    @classmethod
-    def _get_client(cls) -> docker.DockerClient:
-        if cls.client is None:
-            cls.client = docker.from_env()
-        return cls.client
+    for image in result:
+        api_image_result = {}
+        if image["is_official"]:
+            api_image_result["full_image"] = f'library/{image["name"]}:latest'
+        else:
+            api_image_result["full_image"] = f'{image["name"]}:latest'
+        api_image_result["description"] = image["description"]
+        images_to_return.append(api_image_result)
+    return images_to_return
 
-    @classmethod
-    def search_registry(cls, term: str) -> List[DockerImageResult]:
-        """
-        List all images in registry starting with a certain term.
-        """
-        client = cls._get_client()
-        result: List[DockerImageResultFromRegistry] = client.images.search(term=term, limit=30)
-        images_to_return: List[DockerImageResult] = []
 
-        for image in result:
-            api_image_result = {}
-            if image["is_official"]:
-                api_image_result["full_image"] = f'library/{image["name"]}:latest'
-            else:
-                api_image_result["full_image"] = f'{image["name"]}:latest'
-            api_image_result["description"] = image["description"]
-            images_to_return.append(api_image_result)
-        return images_to_return
+def login_to_docker_registry(username: str, password: str, registry_url: str = DOCKER_HUB_REGISTRY_URL) -> bool:
+    """
+    Login to docker registry
 
-    @classmethod
-    def login(cls, username: str, password: str, registry_url: str = DOCKER_HUB_REGISTRY_URL) -> bool:
-        """
-        List all images in registry starting with a certain term.
-        """
-        client = cls._get_client()
-        try:
-            client.login(username, password, registry_url, reauth=True)
-            return True
-        except docker.errors.APIError:
-            return False
+    :returns:
+        True if the operation was succesfull and False if the credentials weren't correct
+    """
+    client = get_docker_client()
+    try:
+        client.login(username, password, registry_url, reauth=True)
+        return True
+    except docker.errors.APIError:
+        return False
 
-    @classmethod
-    def cleanup_project_resources(cls, project: Project):
-        """
-        TODO : we will need to cleanup :
-          - services
-          - workers &
-          - CRONs
-          - volumes
 
-        It returns None when everything has gone well, else it will return errors
-        """
-        client = cls._get_client()
+def cleanup_project_resources(project: Project):
+    """
+    Cleanup all resources attached to a project after it has been archived, which means :
+    - cleaning up volumes (and deleting them in the DB & docker)
+    - cleaning up CRONS
+    - cleaning up Workers
+    - cleaning up services (and deleting the attached volumes)
+    - cleaning up docker networks
+    - ... (TODO)
 
-        try:
-            network_associated_to_project = client.networks.get(get_resource_name(project, resource_type='network'))
-            network_associated_to_project.remove()
-        except docker.errors.NotFound:
-            # We will assume the network has been deleted before
-            pass
+    TODO : we will need to cleanup :
+      - services
+      - workers &
+      - CRONs
+      - volumes
+    """
+    client = get_docker_client()
 
-    @classmethod
-    def create_project_resources(cls, project: Project):
-        client = cls._get_client()
-        client.networks.create(
-            name=get_resource_name(project, resource_type='network'),
-            scope="swarm",
-            driver="overlay",
+    try:
+        network_associated_to_project = client.networks.get(get_resource_name(project, resource_type='network'))
+        network_associated_to_project.remove()
+    except docker.errors.NotFound:
+        # We will assume the network has been deleted before
+        pass
+
+
+def create_project_resources(project: Project):
+    """
+    Create the resources for the project, here it is mainly the project shared network
+    """
+    client = get_docker_client()
+    client.networks.create(
+        name=get_resource_name(project, resource_type='network'),
+        scope="swarm",
+        driver="overlay",
+    )
+
+
+def check_if_port_is_available(port: int) -> bool:
+    client = get_docker_client()
+    try:
+        client.containers.run(
+            image='nginx:alpine',
+            ports={'80/tcp': ('0.0.0.0', port)},
+            command="echo hello world",
+            remove=True
         )
-
-    @classmethod
-    def check_if_port_is_available(cls, port: int) -> bool:
-        client = cls._get_client()
-        try:
-            client.containers.run(
-                image='nginx:alpine-perl',
-                ports={'80/tcp': ('0.0.0.0', port)},
-                command="echo hello world",
-                remove=True
-            )
-            return True
-        except docker.errors.APIError:
-            return False
-
-
-def get_resource_name(project: Project, resource_type: str) -> str:
-    match resource_type:
-        case 'network':
-            ts_to_full_number = str(project.created_at.timestamp()).replace(".", "")
-            return f"{project.slug}-{ts_to_full_number}"
-        case _:
-            raise ValueError(f"resource type '{resource_type}' is not supported")
+        return True
+    except docker.errors.APIError:
+        return False

--- a/backend/zane_api/tests/docker.py
+++ b/backend/zane_api/tests/docker.py
@@ -48,13 +48,13 @@ class FakeDockerClient:
             raise docker.errors.APIError("Bad Credentials")
 
 
-@patch("zane_api.views.docker.DockerService._get_client", wraps=FakeDockerClient)
 class DockerViewTests(AuthAPITestCase):
     def setUp(self):
         super().setUp()
         self.loginUser()
 
-    def test_search_docker_images(self, _: Mock):
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
+    def test_search_docker_images(self, mock_fake_docker: Mock):
         response = self.client.get(
             reverse("zane_api:docker.image_search"), QUERY_STRING="q=caddy"
         )
@@ -65,10 +65,12 @@ class DockerViewTests(AuthAPITestCase):
         self.assertEqual(images[0]["full_image"], "library/caddy:latest")
         self.assertEqual(images[1]["full_image"], "siwecos/caddy:latest")
 
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_search_query_empty(self, _: Mock):
         response = self.client.get(reverse("zane_api:docker.image_search"))
         self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
 
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_success_validate_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
@@ -80,6 +82,7 @@ class DockerViewTests(AuthAPITestCase):
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_bad_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
@@ -91,6 +94,7 @@ class DockerViewTests(AuthAPITestCase):
 
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_bad_request_for_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
@@ -102,8 +106,8 @@ class DockerViewTests(AuthAPITestCase):
         self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
 
 
-@patch("zane_api.views.docker.DockerService._get_client", wraps=FakeDockerClient)
 class DockerPortMappingViewTests(AuthAPITestCase):
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_successfull(self, _: Mock):
         self.loginUser()
         response = self.client.post(
@@ -115,6 +119,7 @@ class DockerPortMappingViewTests(AuthAPITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json().get("available"), True)
 
+    @patch("zane_api.services.get_docker_client", return_value=FakeDockerClient())
     def test_unavailable_port(self, _: Mock):
         self.loginUser()
         response = self.client.post(

--- a/backend/zane_api/views/docker.py
+++ b/backend/zane_api/views/docker.py
@@ -7,7 +7,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .. import serializers
-from ..services import DockerService
+from ..services import (
+    search_docker_registry,
+    check_if_port_is_available,
+    login_to_docker_registry
+)
 
 
 class DockerImageSerializer(serializers.Serializer):
@@ -51,7 +55,7 @@ class DockerImageSearchView(APIView):
 
         if form.is_valid():
             params = form.data
-            result = DockerService.search_registry(term=params["q"])
+            result = search_docker_registry(term=params["q"])
             response = self.serializer_class({"images": result})
             return Response(response.data, status=status.HTTP_200_OK)
 
@@ -91,7 +95,7 @@ class DockerLoginView(APIView):
 
         if form.is_valid():
             data = form.data
-            result = DockerService.login(**data)
+            result = login_to_docker_registry(**data)
 
             if not result:
                 response = self.error_serializer_class(
@@ -136,7 +140,7 @@ class DockerPortCheckView(APIView):
 
         if form.is_valid():
             data = form.data
-            result = DockerService.check_if_port_is_available(port=data["port"])
+            result = check_if_port_is_available(port=data["port"])
 
             response = self.serializer_class({"available": result})
             return Response(

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -11,7 +11,7 @@ from rest_framework.views import APIView
 from . import EMPTY_RESPONSE
 from .. import serializers
 from ..models import Project
-from ..services import DockerService
+from ..services import create_project_resources, cleanup_project_resources
 
 
 class ProjectSuccessResponseSerializer(serializers.Serializer):
@@ -122,7 +122,7 @@ class ProjectsListView(APIView):
                     new_project = Project.objects.create(
                         name=data["name"], slug=slug, owner=request.user
                     )
-                DockerService.create_project_resources(project=new_project)
+                create_project_resources(project=new_project)
                 response = self.single_serializer_class({"project": new_project})
                 return Response(response.data, status=status.HTTP_201_CREATED)
             except IntegrityError:
@@ -236,7 +236,7 @@ class ProjectDetailsView(APIView):
     def delete(self, request: Request, slug: str) -> Response:
         try:
             project = Project.objects.get(slug=slug, archived=False)
-            DockerService.cleanup_project_resources(project)
+            cleanup_project_resources(project)
             project.archived = True
             project.save()
         except Project.DoesNotExist:


### PR DESCRIPTION
## Description

This pull request is mostly cleanup job, I wanted to move from classes to functions because I didn't want to instantiate the `DockerService` manually on each call, and I have noticed that I made all methods classmethods while they really don't have any need for it to be like that. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
make openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
make freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
