### PR TITLE
:recycle: Add resource labels on project

### DIFF
--- a/backend/zane_api/services.py
+++ b/backend/zane_api/services.py
@@ -29,6 +29,10 @@ def get_resource_name(project: Project, resource_type: str) -> str:
             raise ValueError(f"resource type '{resource_type}' is not supported")
 
 
+def get_resource_labels(project: Project):
+    return {"zane-managed": "true", "zane-project": project.slug}
+
+
 class DockerImageResultFromRegistry(TypedDict):
     name: str
     description: str
@@ -110,6 +114,7 @@ def create_project_resources(project: Project):
         name=get_resource_name(project, resource_type='network'),
         scope="swarm",
         driver="overlay",
+        labels=get_resource_labels(project)
     )
 
 

--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -32,7 +32,7 @@ class FakeDockerClientWithNetworks:
         self.networks.create = self.docker_create_network
         self.networks.get = self.docker_get_network
 
-    def docker_create_network(self, name: str, scope: str, driver: str):
+    def docker_create_network(self, name: str, **kwargs):
         if self.raise_error_on_create:
             raise docker.errors.APIError('Unknown error when creating a network')
 


### PR DESCRIPTION
## Description

This small PR is for adding labels to resources so that outside they are marked as managed by zaneops.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
make openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
make freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
